### PR TITLE
Pin kernel source hash

### DIFF
--- a/rM/linux-remarkable/src.nix
+++ b/rM/linux-remarkable/src.nix
@@ -1,12 +1,11 @@
-
 { fetchFromGitHub, }:
 
 {
   src = fetchFromGitHub {
     owner = "reMarkable";
     repo = "linux";
-    rev = "lars/zero-gravitas_4.9";
-    hash = "sha256-WKOqSZKD1fkOQ4mgy0cehMdlcKu1yeEhnwFtAdRkkrM=";
+    rev = "1774e2a6a091fdc081324e966d3db0aa9df75c0b";
+    sha256 = "0pjk6ag2s685ar6d31sx484k1wyhyn7g7mz9zib910zcmfb3rdqf";
   };
   version = "4.9.84-zero-gravitas";
 }


### PR DESCRIPTION
Some new commits were pushed to the `lars/zero-gravitas_4.9` branch of the reMarkable kernel, changing the hash of the kernel source, and breaking the mxc_epdc_fb_damage build. I changed `rev` to point to the most recent commit on that branch and updated the hash.